### PR TITLE
update minimist dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
     "name": "Yashprit",
     "email": "yashprit@gmail.com"
   },
-  "contributors": [{
-    "url": "womack.io",
-    "name": "James J. Womack",
-    "email": "james@womack.io"
-  }],
+  "contributors": [
+    {
+      "url": "womack.io",
+      "name": "James J. Womack",
+      "email": "james@womack.io"
+    }
+  ],
   "engines": {
     "node": ">=0.10.0"
   },
@@ -35,7 +37,7 @@
     "javascript"
   ],
   "dependencies": {
-    "minimist": "1.1.1"
+    "minimist": "^1.2.5"
   },
   "devDependencies": {
     "mocha": "2.2.5"


### PR DESCRIPTION
It was recently found that minimist had some prototype pollution vulnerabilities on versions < 1.2.3. This PR updates the minimist dependency to a version that fixes this issue as well as re-adds the carot operator removed in #1 so that if there's future updates that fix these sorts of things, is-float can automatically take advantage of them (and minimist is quite good about sticking to strict semver).